### PR TITLE
Fixes image extending beyond view's bounds on zoom

### DIFF
--- a/FDWaveformView/FDWaveformView.m
+++ b/FDWaveformView/FDWaveformView.m
@@ -68,6 +68,7 @@
     [self.clipping addSubview:self.highlightedImage];
     self.clipping.clipsToBounds = YES;
     [self addSubview:self.clipping];
+    self.clipsToBounds = YES;
     
     self.wavesColor = [UIColor blackColor];
     self.progressColor = [UIColor blueColor];


### PR DESCRIPTION
When zooming the waveform grows larger than the waveformview's frame. This fixes the issue by enabling clipToBounds on the waveformview
