### PR TITLE
Update FDWaveformView.m

### DIFF
--- a/FDWaveformView/FDWaveformView.m
+++ b/FDWaveformView/FDWaveformView.m
@@ -175,7 +175,7 @@
 {
     [super layoutSubviews];
     
-    if (!self.asset || self.renderingInProgress)
+    if (!self.asset || self.renderingInProgress || self.zoomEndSamples == 0)
         return;
     
     unsigned long int displayRange = self.zoomEndSamples - self.zoomStartSamples;


### PR DESCRIPTION
added check for self.zoomEndSamples == 0 to skip calls to layoutSubviews before image loaded
