### PR TITLE
Show a line when there's no audio

### DIFF
--- a/Pod/Classes/FDWaveformView.m
+++ b/Pod/Classes/FDWaveformView.m
@@ -352,6 +352,9 @@
     for (NSInteger intSample=0; intSample<sampleCount; intSample++) {
         Float32 sample = *samples++;
         float pixels = (sample - noiseFloor) * sampleAdjustmentFactor;
+        if (pixels == 0) {
+            pixels = 1;
+        }
         CGContextMoveToPoint(context, intSample, centerLeft-pixels);
         CGContextAddLineToPoint(context, intSample, centerLeft+pixels);
         CGContextStrokePath(context);


### PR DESCRIPTION
This will ensure there's always a line shown when displaying a waveform