### PR TITLE
Use accelerate

### DIFF
--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -415,19 +415,19 @@ public class FDWaveformView: UIView {
                         vDSP_Length(samplesPerPixel))
 
             let range = nextDataOffset..<(nextDataOffset+downSampledLength)
-            var downSampledDataCG = downSampledData.map { CGFloat($0) }
-            if let newMax = downSampledDataCG.maxElement() where newMax > sampleMax {
-                sampleMax = newMax
+            var downSampledDataCG = downSampledData.map { (value: Float) -> CGFloat in
+                let element = CGFloat(value)
+                if element > sampleMax { sampleMax = element }
+                return element
             }
 
-            outputSamples += downSampledDataCG.prefix(downSampledLength)
+            outputSamples += downSampledDataCG
             nextDataOffset += downSampledLength
         }
         // if (reader.status == AVAssetReaderStatusFailed || reader.status == AVAssetReaderStatusUnknown)
         // Something went wrong. Handle it.
         if reader.status == .Completed {
-            let outputSamplesCG = outputSamples.map { CGFloat($0) }
-            done(samples: outputSamplesCG, sampleMax: sampleMax)
+            done(samples: outputSamples, sampleMax: sampleMax)
         } else {
             print(reader.status)
         }


### PR DESCRIPTION
From [Issue 60](https://github.com/fulldecent/FDWaveformView/issues/60)

Notes:
- This supports multi-channel rendering. I believe it only scanned the first channel before, I could be wrong. If it only supported single channel before, it supports multi-channel now. 
- This is a big change, I recommend taking some time to review the code to make sure everything is written well. Also testing on your own device would be nice.
- I did see a performance increase as noted below. I tried my best to optimize all of the code efficiently as possible, as noted in some of the comments below.

After finishing, I tested the performance on my iPhone 5s. Each profile had a fresh install of the iOS Example App. (Apologies for large image size)

Before accelerate:
![img_8270](https://cloud.githubusercontent.com/assets/9373998/18414790/32beb89c-77a5-11e6-8e93-243286854391.PNG)

After accelerate:
![img_8269](https://cloud.githubusercontent.com/assets/9373998/18414789/32aed5a8-77a5-11e6-9776-e3a2149b3583.PNG)


