### PR TITLE
Allow scrubbing independantly of scrolling

### DIFF
--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -541,10 +541,10 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
                 self.setNeedsDisplay()
                 self.setNeedsLayout()
             }
-            else if self.doesAllowScrubbing {
-                let rangeSamples = CGFloat(zoomEndSamples - zoomStartSamples)
-                progressSamples = Int(CGFloat(zoomStartSamples) + rangeSamples * recognizer.location(in: self).x / self.bounds.size.width)
-            }
+        }
+        else if self.doesAllowScrubbing {
+            let rangeSamples = CGFloat(zoomEndSamples - zoomStartSamples)
+            progressSamples = Int(CGFloat(zoomStartSamples) + rangeSamples * recognizer.location(in: self).x / self.bounds.size.width)
         }
     }
 


### PR DESCRIPTION
I think this may have just been a bug from the port, so this now allows scrubbing to work when scrolling is disabled. The logic may be a bit flawed when scrubbing and scrolling are enabled, but I'm not sure if you would actually want to scrub and scroll with the same gesture anyway?