### PR TITLE
More accurately process samples and properly handle large files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Released on 2017-02-16.
   - Added by [Doug Earnshaw](https://github.com/haydenholligan)
 - Tidy up Swift 3.0 conversion, remove some forced unwraps & generally make more Swifty
   - Added by [Doug Earnshaw](https://github.com/haydenholligan)
+- Improved accuracy of waveform rendering
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Fixed waveform rendering for large audio files
+  - Added by [Kip Nicol](https://github.com/ospr)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Master](https://github.com/fulldecent/FDWaveformView/compare/2.0.1...master)
 
+#### Fixed
+- Improved accuracy of waveform rendering
+  - Added by [Kip Nicol](https://github.com/ospr)
+- Fixed waveform rendering for large audio files
+  - Added by [Kip Nicol](https://github.com/ospr)
+
 ---
 
 ## [2.0.1](https://github.com/fulldecent/FDWaveformView/releases/tag/2.0.1)
@@ -16,10 +22,6 @@ Released on 2017-02-16.
   - Added by [Doug Earnshaw](https://github.com/haydenholligan)
 - Tidy up Swift 3.0 conversion, remove some forced unwraps & generally make more Swifty
   - Added by [Doug Earnshaw](https://github.com/haydenholligan)
-- Improved accuracy of waveform rendering
-  - Added by [Kip Nicol](https://github.com/ospr)
-- Fixed waveform rendering for large audio files
-  - Added by [Kip Nicol](https://github.com/ospr)
 
 ---
 


### PR DESCRIPTION
This is a fix for https://github.com/fulldecent/FDWaveformView/issues/78

This fixes two bugs in current master:

- The call to `vDSP_desamp` when processing samples will only process a portion of the samples in `processingBuffer` (`samplesPerPixel * downSampledLength` samples which is most likely less than `processingBuffer.count`). The final samples are then just thrown away on the next sample processing iteration. Instead of throwing these away, we now save them in a `sampleBuffer` to process on the next iteration.
- For larger audio files where `samplesToProcess` is less than `samplesPerPixel` the `downSampledLength` becomes zero and we end up with an empty `outputSamples` array at the very end resulting in an empty waveform image. Now we keep a long running buffer, `sampleBuffer`, of the unprocessed samples, and if there aren't enough samples we skip processing for that iteration and continue to append to `sampleBuffer` until there are enough samples.

Note that this fixes the same bugs as noted in https://github.com/fulldecent/FDWaveformView/pull/74, but, from my tests, does not have any performance regressions.
