### PR TITLE
Add scrubbing delegate and fix scrubbing crash

### DIFF
--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -545,6 +545,7 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
         else if doesAllowScrubbing {
             let rangeSamples = CGFloat(zoomSamples.count)
             highlightedSamples = 0 ..< Int((CGFloat(zoomSamples.startIndex) + rangeSamples * recognizer.location(in: self).x / bounds.width))
+            delegate?.waveformDidEndScrubbing?(self)
         }
     }
     
@@ -552,6 +553,7 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
         if doesAllowScrubbing {
             let rangeSamples = CGFloat(zoomSamples.count)
             highlightedSamples = 0 ..< Int((CGFloat(zoomSamples.startIndex) + rangeSamples * recognizer.location(in: self).x / bounds.width))
+            delegate?.waveformDidEndScrubbing?(self)
         }
     }
 }
@@ -575,6 +577,9 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
     
     /// The panning gesture did end
     @objc optional func waveformDidEndPanning(_ waveformView: FDWaveformView)
+    
+    /// The scrubbing gesture did end
+    @objc optional func waveformDidEndScrubbing(_ waveformView: FDWaveformView)
 }
 
 //MARK -

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -544,7 +544,8 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
         }
         else if doesAllowScrubbing {
             let rangeSamples = CGFloat(zoomSamples.count)
-            highlightedSamples = 0 ..< Int((CGFloat(zoomSamples.startIndex) + rangeSamples * recognizer.location(in: self).x / bounds.width))
+            let scrubLocation = min(max(recognizer.location(in: self).x, 0), frame.width)    // clamp location within the frame
+            highlightedSamples = 0 ..< Int((CGFloat(zoomSamples.startIndex) + rangeSamples * scrubLocation / bounds.width))
             delegate?.waveformDidEndScrubbing?(self)
         }
     }


### PR DESCRIPTION
This is effectively a duplicate of #94 but without any conflicts.

Additionally it fixes a crash that could occur when a scrub's location moved outside of the frame (so as to have a negative x coordinate). 