### PR TITLE
Add property to change scrubbing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## [Master](https://github.com/fulldecent/FDWaveformView/compare/4.0.0...master)
+#### Added
+- Scrubbing can now update both the start and end of the highlighted samples range.
+  - Added by [Doug Earnshaw](https://github.com/pixlwave)
 
 #### Changed
 - Switch to new standard library clamp functions

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -589,12 +589,17 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
     
     /// Updates highlightedSamples with the sample passed in, taking into account the value of boundToScrub
     func scrub(to sample: Int) {
-        if boundToScrub == .upper, let lowerBound = highlightedSamples?.lowerBound, sample > lowerBound {
-            highlightedSamples = lowerBound ..< sample
-            delegate?.waveformDidEndScrubbing?(self)
-        } else if let upperBound = highlightedSamples?.upperBound, sample < upperBound {
-            highlightedSamples = sample ..< upperBound
-            delegate?.waveformDidEndScrubbing?(self)
+        switch boundToScrub {
+        case .upper:
+            if let lowerBound = highlightedSamples?.lowerBound, sample > lowerBound {
+                highlightedSamples = lowerBound ..< sample
+                delegate?.waveformDidEndScrubbing?(self)
+            }
+        case .lower:
+            if let upperBound = highlightedSamples?.upperBound, sample < upperBound {
+                highlightedSamples = sample ..< upperBound
+                delegate?.waveformDidEndScrubbing?(self)
+            }
         }
     }
 }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -79,13 +79,13 @@ open class FDWaveformView: UIView {
     /// Pan gives priority to `doesAllowScroll` if this and that are both `true`
     /*@IBInspectable*/ open var doesAllowScrubbing = true
     
-    /// Supported bounds for scrubbing
-    public enum ScrubbingBound {
-        case lower, upper
+    /// Supported scrub types
+    public enum ScrubType {
+        case highlightStart, highlightEnd
     }
     
     /// Whether scrubbing affects the start or end of highlighted samples
-    open var boundToScrub = ScrubbingBound.upper
+    open var scrubbing = ScrubType.highlightEnd
 
     /// Whether to allow pinch gesture to change zoom
     /*@IBInspectable*/ open var doesAllowStretch = true
@@ -587,17 +587,17 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
         }
     }
     
-    /// Updates highlightedSamples with the sample passed in, taking into account the value of boundToScrub
+    /// Updates highlightedSamples with the sample passed in, taking into account the current scrub type
     func scrub(to sample: Int) {
-        switch boundToScrub {
-        case .upper:
-            if let lowerBound = highlightedSamples?.lowerBound, sample > lowerBound {
-                highlightedSamples = lowerBound ..< sample
+        switch scrubbing {
+        case .highlightEnd:
+            if let startSample = highlightedSamples?.lowerBound, sample > startSample {
+                highlightedSamples = startSample ..< sample
                 delegate?.waveformDidEndScrubbing?(self)
             }
-        case .lower:
-            if let upperBound = highlightedSamples?.upperBound, sample < upperBound {
-                highlightedSamples = sample ..< upperBound
+        case .highlightStart:
+            if let endSample = highlightedSamples?.upperBound, sample < endSample {
+                highlightedSamples = sample ..< endSample
                 delegate?.waveformDidEndScrubbing?(self)
             }
         }

--- a/Source/FDWaveformView.swift
+++ b/Source/FDWaveformView.swift
@@ -587,6 +587,7 @@ extension FDWaveformView: UIGestureRecognizerDelegate {
         }
     }
     
+    /// Updates highlightedSamples with the sample passed in, taking into account the value of boundToScrub
     func scrub(to sample: Int) {
         if boundToScrub == .upper, let lowerBound = highlightedSamples?.lowerBound, sample > lowerBound {
             highlightedSamples = lowerBound ..< sample


### PR DESCRIPTION
The boundToScrub property allows for the choice of scrubbing to affect either the start or end of the highlighted samples range. Really not sure on the most clear terminology to use, so please review this to make sure you're happy with the names used.