### PR TITLE
Bump swift tools version to 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:4.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,29 @@
 // swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(
-  name: "FDWaveformView"
+    name: "FDWaveformView",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "FDWaveformView",
+            targets: ["FDWaveformView"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "FDWaveformView",
+            path: "Source"),
+        .testTarget(
+            name: "FDWaveformViewTests",
+            dependencies: ["FDWaveformView"],
+            path: "Tests"),
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,23 +1,16 @@
 // swift-tools-version:4.2
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "FDWaveformView",
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "FDWaveformView",
             targets: ["FDWaveformView"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
+    dependencies: [],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "FDWaveformView",
             path: "Source"),


### PR DESCRIPTION
I encountered a problem while trying to add FDWaveformView to a Swift 5.1 project with SPM (File/Swift Packages/Add Package Dependency) - turned out swift-tools-version: 3.0 is unsupported in newest xcode. I edited `Package.swift` to make it compilable with SPM.

note: I used swif-tools-version:4.2 becuse it was the lowest I could get without errors (4.0 and 4.1 produced an error with `CMBlockBufferGetDataPointer()` argument labels 🤯)

Feel free to check and point out any issues with this PR :)