### PR TITLE
Ensure the timescale of the reader's range is the audio's sample rate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 #### Changed
 - Switch to new standard library clamp functions
   - Added by [William Entriken](https://github.com/fulldecent)
+- Fixed timescale bug for some mp4 files
+  - Added by [Doug Earnshaw](https://github.com/pixlwave)
 
 ---
 


### PR DESCRIPTION
Sometimes mp4 audio originally coming from some video sources, has a timescale relevant to the video format rather than the audio's sample rate. Rendering a waveform for these files would work until you zoomed in, at which point the waveform would disappear. This fixes this by reading the sample rate from the format description and using that.